### PR TITLE
Fix incorrect `patch` level comparison

### DIFF
--- a/Sources/Hawk/Core/Hawk.swift
+++ b/Sources/Hawk/Core/Hawk.swift
@@ -77,17 +77,19 @@ struct Hawk {
             return storeVersion.major > localVersion.major
 
         case .minor:
-            if storeVersion.major > localVersion.major {
-                return true
+            if storeVersion.major != localVersion.major {
+                return storeVersion.major > localVersion.major
             }
-            if storeVersion.major == localVersion.major,
-               storeVersion.minor > localVersion.minor {
-                return true
-            }
-            return false
+            return storeVersion.minor > localVersion.minor
 
         case .patch:
-            return storeVersionString.compare(localVersionString) == .orderedDescending
+            if storeVersion.major != localVersion.major {
+                return storeVersion.major > localVersion.major
+            }
+            if storeVersion.minor != localVersion.minor {
+                return storeVersion.minor > localVersion.minor
+            }
+            return storeVersion.patch > localVersion.patch
         }
     }
 }


### PR DESCRIPTION
バージョン比較において，文字列の辞書順での比較を利用すると，以下のようなケースで問題になりそうです．

```
1.2.3 vs 1.12.3 
```

本プルリクでは，patchレベルでの比較でも数値型同士で比較を行うように修正しました．

なお，`compare`メソッドに`.numeric`オプションを指定することで，文字列でも数値ベースでの比較が可能なようです．
[reference](https://developer.apple.com/documentation/foundation/nsstring/compareoptions/1415530-numeric)

```swift
storeVersionString.compare(localVersionString, options: .numeric) == .orderedDescending
```