### PR TITLE
Support custom dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Hawk is a Swift library that detects when a force update is required and, if nec
 ## Features
 - Checks the current app version against the App Store version.  
 - Displays a alert to prompt users to update.  
-- Automatically redirects the user to your app’s page on the App Store.
+- Automatically redirects the user to your app's page on the App Store.
 - Flexible Version Comparison: Choose the level of comparison (major, minor, or patch) using the UpdateLevel enum.
+- **Custom Dialog Support**: Create your own custom update dialogs instead of using the default alert.
 
 ## Example
 Check out the example application to see Hawk in action. Simply open the `Example-SwiftUI/Example-SwiftUI.xcodeproj` or `Example-UIKit/Example-UIKit.xcodeproj` and run.
@@ -28,7 +29,7 @@ dependencies: [
 ```
  
 ## Configuration
-Inside your app’s Info.plist, add a key called `AppStoreID` with your app’s App Store ID as the value. For example:
+Inside your app's Info.plist, add a key called `AppStoreID` with your app's App Store ID as the value. For example:
 
 ```
 <key>AppStoreID</key>
@@ -45,6 +46,8 @@ Hawk provides an enum called UpdateLevel for specifying how strictly versions ar
 
 ### UIKit
 In any UIViewController, call the force update method at your preferred timing (e.g., viewWillAppear):
+
+#### Default Alert
 ```swift
 import UIKit
 import Hawk
@@ -59,11 +62,35 @@ class ViewController: UIViewController {
         view.backgroundColor = .green
     }
 }
+```
 
+#### Custom Dialog
+```swift
+import UIKit
+import Hawk
+
+class ViewController: UIViewController {
+    override func viewWillAppear(_ animated: Bool) {
+        showForceUpdateDialogIfNeeded(level: .minor) {
+            let customView = UIView()
+            let button = UIButton(type: .system)
+            button.setTitle("Open App Store", for: .normal)
+            button.addTarget(self, action: #selector(openAppStore), for: .touchUpInside)
+            customView.addSubview(button)
+            return customView
+        }
+    }
+
+    @objc private func openAppStore() {
+        Hawk.openAppStore()
+    }
+}
 ```
 
 ### SwiftUI
 Simply attach the forceUpdateCheck view modifier to any View. For example:
+
+#### Default Alert
 ```swift
 import SwiftUI
 import Hawk
@@ -75,7 +102,31 @@ struct ContentView: View {
     }
 }
 ```
-When the view appears, the library checks the local version against the App Store version. If an update is required, a SwiftUI alert appears prompting the user to update.
+
+#### Custom Dialog
+```swift
+import SwiftUI
+import Hawk
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, World!")
+            .showForceUpdateDialogIfNeeded(level: .minor) {
+                VStack {
+                    Text("New version is available")
+                    Button("Open App Store") {
+                        Hawk.openAppStore()
+                    }
+                }
+                .padding()
+                .background(Color.white)
+                .cornerRadius(10)
+            }
+    }
+}
+```
+
+When the view appears, the library checks the local version against the App Store version. If an update is required, either a default alert or your custom dialog appears prompting the user to update.
 
 ## License
 Hawk is released under the MIT License. See [LICENSE](https://github.com/reeen21/Hawk/blob/main/LICENSE) for details.

--- a/Sources/Hawk/Core/Hawk.swift
+++ b/Sources/Hawk/Core/Hawk.swift
@@ -4,8 +4,7 @@ import SwiftUI
  * A service that manages version checks against the App Store, determining whether
  * a force update is necessary based on a given update level.
  */
-struct Hawk {
-
+public enum Hawk {
     /**
      * Checks if a force update is needed by comparing the local app version to the
      * App Store version or the versions provided explicitly.
@@ -90,6 +89,15 @@ struct Hawk {
                 return storeVersion.minor > localVersion.minor
             }
             return storeVersion.patch > localVersion.patch
+        }
+    }
+
+    @MainActor
+    public static func openAppStore() {
+        if let appId = Bundle.main.object(forInfoDictionaryKey: "AppStoreID") as? String,
+           let url = URL(string: "https://apps.apple.com/jp/app/id\(appId)")
+        {
+            UIApplication.shared.open(url)
         }
     }
 }

--- a/Sources/Hawk/Core/Hawk.swift
+++ b/Sources/Hawk/Core/Hawk.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 
-/**
- * A service that manages version checks against the App Store, determining whether
- * a force update is necessary based on a given update level.
- */
+/// A service that manages version checks against the App Store, determining whether
+/// a force update is necessary based on a given update level.
 public enum Hawk {
     /**
      * Checks if a force update is needed by comparing the local app version to the
@@ -23,32 +21,36 @@ public enum Hawk {
         storeVersion: String? = nil
     ) async -> Bool {
         do {
-            // If localVersion and storeVersion are provided, compare directly:
             if let localVersion, let storeVersion {
                 return needsForceUpdate(local: localVersion, store: storeVersion, level: level)
             }
 
-            // Otherwise, fetch the store version from the App Store:
             guard let appId = Bundle.main.object(forInfoDictionaryKey: "AppStoreID") as? String,
-                  let url = URL(string: "https://itunes.apple.com/jp/lookup?id=\(appId)") else {
+                let url = URL(string: "https://itunes.apple.com/jp/lookup?id=\(appId)")
+            else {
                 return false
             }
 
             let (data, response) = try await URLSession.shared.data(from: url)
             guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200,
-                  let jsonData = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let results = jsonData["results"] as? [[String: Any]],
-                  let firstResult = results.first,
-                  let storeVersionString = firstResult["version"] as? String else {
+                httpResponse.statusCode == 200,
+                let jsonData = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let results = jsonData["results"] as? [[String: Any]],
+                let firstResult = results.first,
+                let storeVersionString = firstResult["version"] as? String
+            else {
                 return false
             }
 
-            guard let appVersionString = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
+            guard
+                let appVersionString = Bundle.main.object(
+                    forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            else {
                 return false
             }
 
-            return needsForceUpdate(local: appVersionString, store: storeVersionString, level: level)
+            return needsForceUpdate(
+                local: appVersionString, store: storeVersionString, level: level)
         } catch {
             return false
         }
@@ -92,10 +94,24 @@ public enum Hawk {
         }
     }
 
+    /**
+     * Opens the App Store page for the current app.
+     * This method uses the AppStoreID from the app's Info.plist to construct the App Store URL.
+     *
+     * ## Usage
+     * This method can be called directly from custom dialogs or anywhere in your app
+     * where you need to redirect users to the App Store.
+     *
+     * ```swift
+     * Button("Open App Store") {
+     *     Hawk.openAppStore()
+     * }
+     * ```
+     */
     @MainActor
     public static func openAppStore() {
         if let appId = Bundle.main.object(forInfoDictionaryKey: "AppStoreID") as? String,
-           let url = URL(string: "https://apps.apple.com/jp/app/id\(appId)")
+            let url = URL(string: "https://apps.apple.com/jp/app/id\(appId)")
         {
             UIApplication.shared.open(url)
         }

--- a/Sources/Hawk/Public Extensions/SwiftUI+CustomDialogModifier.swift
+++ b/Sources/Hawk/Public Extensions/SwiftUI+CustomDialogModifier.swift
@@ -1,0 +1,49 @@
+//
+//  SwiftUI+CustomDialogModifier.swift
+//  Hawk
+//
+//  Created by reeen on 2025/06/30.
+//
+
+import SwiftUI
+
+private struct CustomDialogModifier: ViewModifier {
+    @State private var showUpdateAlert = false
+    let updateLevel: UpdateLevel
+    let customDialog: AnyView
+
+    func body(content: Content) -> some View {
+        ZStack {
+            if showUpdateAlert {
+                customDialog
+            }
+
+            content
+                .task {
+                    let needUpdate = await Hawk.checkIsNeedForceUpdate(level: updateLevel)
+                    if needUpdate {
+                        showUpdateAlert = true
+                    }
+                }
+        }
+    }
+}
+
+extension View {
+    /// Checks if the app needs to be force-updated and displays a custom dialog.
+    ///
+    /// - Parameters:
+    ///   - level: The threshold for determining a required update (default is `.minor`).
+    ///   - content: The custom view to display when an update is needed.
+    /// - Returns: A view modified to check for a force update with custom dialog.
+    public func showForceUpdateDialogIfNeeded<Content: View>(
+        level: UpdateLevel = .minor,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        modifier(
+            CustomDialogModifier(
+                updateLevel: level,
+                customDialog: AnyView(content())
+            ))
+    }
+}

--- a/Sources/Hawk/Public Extensions/SwiftUI+CustomDialogModifier.swift
+++ b/Sources/Hawk/Public Extensions/SwiftUI+CustomDialogModifier.swift
@@ -7,11 +7,32 @@
 
 import SwiftUI
 
+/// A view modifier that checks if a force update is required and displays a custom dialog
+/// when an update is needed. This modifier allows you to create your own custom update dialog
+/// instead of using the default alert.
 private struct CustomDialogModifier: ViewModifier {
+    /**
+     * Indicates whether the custom update dialog should be shown. Defaults to `false`.
+     */
     @State private var showUpdateAlert = false
+
+    /**
+     * Determines the level of update to check (major, minor, or patch).
+     */
     let updateLevel: UpdateLevel
+
+    /**
+     * The custom view to display when an update is needed.
+     */
     let customDialog: AnyView
 
+    /**
+     * Constructs the body of the view modifier, initiating the force update check
+     * and displaying the custom dialog if needed.
+     *
+     * - Parameter content: The content view that the modifier is applied to.
+     * - Returns: A modified view that performs the force update check with custom dialog.
+     */
     func body(content: Content) -> some View {
         ZStack {
             if showUpdateAlert {
@@ -30,12 +51,31 @@ private struct CustomDialogModifier: ViewModifier {
 }
 
 extension View {
-    /// Checks if the app needs to be force-updated and displays a custom dialog.
-    ///
-    /// - Parameters:
-    ///   - level: The threshold for determining a required update (default is `.minor`).
-    ///   - content: The custom view to display when an update is needed.
-    /// - Returns: A view modified to check for a force update with custom dialog.
+    /**
+     * Checks if the app needs to be force-updated and displays a custom dialog when an update is required.
+     * This method allows you to create your own custom update dialog instead of using the default alert.
+     *
+     * - Parameters:
+     *   - level: The threshold for determining a required update (default is `.minor`).
+     *   - content: A closure that returns the custom view to display when an update is needed.
+     *             You can call `Hawk.openAppStore()` directly within this closure to open the App Store.
+     * - Returns: A view modified to check for a force update with custom dialog.
+     *
+     * ## Example Usage
+     * ```swift
+     * .showForceUpdateDialogIfNeeded(level: .minor) {
+     *     VStack {
+     *         Text("新しいバージョンが利用可能です")
+     *         Button("App Storeを開く") {
+     *             Hawk.openAppStore()
+     *         }
+     *     }
+     *     .padding()
+     *     .background(Color.white)
+     *     .cornerRadius(10)
+     * }
+     * ```
+     */
     public func showForceUpdateDialogIfNeeded<Content: View>(
         level: UpdateLevel = .minor,
         @ViewBuilder content: () -> Content

--- a/Sources/Hawk/Public Extensions/ViewController+showForceUpdateDialogIfNeeded.swift
+++ b/Sources/Hawk/Public Extensions/ViewController+showForceUpdateDialogIfNeeded.swift
@@ -2,10 +2,12 @@ import UIKit
 
 extension UIViewController {
 
-    /// Checks for a forced update at the specified level (major, minor, patch).
-    /// If needed, presents an alert prompting the user to update.
-    ///
-    /// - Parameter level: The update level threshold (default = .minor).
+    /**
+     * Checks for a forced update at the specified level (major, minor, patch).
+     * If needed, presents an alert prompting the user to update.
+     *
+     * - Parameter level: The update level threshold (default = .minor).
+     */
     public func showForceUpdateDialogIfNeeded(level: UpdateLevel = .minor) {
         // Run an asynchronous task on the main actor so alert presentation
         // happens on the main thread.
@@ -17,6 +19,31 @@ extension UIViewController {
         }
     }
 
+    /**
+     * Checks for a forced update and displays a custom dialog when an update is required.
+     * This method allows you to create your own custom update dialog instead of using the default alert.
+     *
+     * - Parameters:
+     *   - level: The update level threshold (default = .minor).
+     *   - customDialog: A closure that returns the custom UIView to display when an update is needed.
+     *                  You can call `Hawk.openAppStore()` directly within this closure to open the App Store.
+     *
+     * ## Example Usage
+     * ```swift
+     * showForceUpdateDialogIfNeeded(level: .minor) {
+     *     let customView = UIView()
+     *     let button = UIButton(type: .system)
+     *     button.setTitle("App Storeを開く", for: .normal)
+     *     button.addTarget(self, action: #selector(openAppStore), for: .touchUpInside)
+     *     customView.addSubview(button)
+     *     return customView
+     * }
+     *
+     * @objc private func openAppStore() {
+     *     Hawk.openAppStore()
+     * }
+     * ```
+     */
     public func showForceUpdateDialogIfNeeded(
         level: UpdateLevel = .minor,
         customDialog: @escaping () -> UIView
@@ -30,7 +57,10 @@ extension UIViewController {
         }
     }
 
-    /// Presents an alert telling the user a new version is available and prompting them to update.
+    /**
+     * Presents an alert telling the user a new version is available and prompting them to update.
+     * This is the default alert implementation used when no custom dialog is provided.
+     */
     private func presentUpdateAlert() {
         let alertController = UIAlertController(
             title: String(localized: "Dialog.Title", bundle: .module),
@@ -41,7 +71,6 @@ extension UIViewController {
         let updateAction = UIAlertAction(
             title: String(localized: "Dialog.ButtonTitle", bundle: .module), style: .default
         ) { _ in
-            // Replace with your real App Store link or logic
             if let appId = Bundle.main.object(forInfoDictionaryKey: "AppStoreID") as? String,
                 let url = URL(string: "https://apps.apple.com/jp/app/id\(appId)")
             {
@@ -53,6 +82,12 @@ extension UIViewController {
         present(alertController, animated: true)
     }
 
+    /**
+     * Presents a custom dialog view as an overlay on the current view controller.
+     * The dialog is centered and has a semi-transparent background.
+     *
+     * - Parameter dialogView: The custom UIView to display as a dialog.
+     */
     private func presentCustomDialog(_ dialogView: UIView) {
         let overlayView = UIView()
         overlayView.backgroundColor = UIColor.black.withAlphaComponent(0.5)

--- a/Sources/Hawk/Public Extensions/ViewController+showForceUpdateDialogIfNeeded.swift
+++ b/Sources/Hawk/Public Extensions/ViewController+showForceUpdateDialogIfNeeded.swift
@@ -1,18 +1,31 @@
 import UIKit
 
-public extension UIViewController {
+extension UIViewController {
 
     /// Checks for a forced update at the specified level (major, minor, patch).
     /// If needed, presents an alert prompting the user to update.
     ///
     /// - Parameter level: The update level threshold (default = .minor).
-    func showForceUpdateDialogIfNeeded(level: UpdateLevel = .minor) {
+    public func showForceUpdateDialogIfNeeded(level: UpdateLevel = .minor) {
         // Run an asynchronous task on the main actor so alert presentation
         // happens on the main thread.
         Task { @MainActor in
             let needsUpdate = await Hawk.checkIsNeedForceUpdate(level: level)
             if needsUpdate {
                 presentUpdateAlert()
+            }
+        }
+    }
+
+    public func showForceUpdateDialogIfNeeded(
+        level: UpdateLevel = .minor,
+        customDialog: @escaping () -> UIView
+    ) {
+        Task { @MainActor in
+            let needUpdate = await Hawk.checkIsNeedForceUpdate(level: level)
+            if needUpdate {
+                let dialogView = customDialog()
+                presentCustomDialog(dialogView)
             }
         }
     }
@@ -25,15 +38,41 @@ public extension UIViewController {
             preferredStyle: .alert
         )
 
-        let updateAction = UIAlertAction(title: String(localized: "Dialog.ButtonTitle", bundle: .module), style: .default) { _ in
+        let updateAction = UIAlertAction(
+            title: String(localized: "Dialog.ButtonTitle", bundle: .module), style: .default
+        ) { _ in
             // Replace with your real App Store link or logic
             if let appId = Bundle.main.object(forInfoDictionaryKey: "AppStoreID") as? String,
-               let url = URL(string: "https://apps.apple.com/jp/app/id\(appId)") {
+                let url = URL(string: "https://apps.apple.com/jp/app/id\(appId)")
+            {
                 UIApplication.shared.open(url)
             }
         }
 
         alertController.addAction(updateAction)
         present(alertController, animated: true)
+    }
+
+    private func presentCustomDialog(_ dialogView: UIView) {
+        let overlayView = UIView()
+        overlayView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        overlayView.translatesAutoresizingMaskIntoConstraints = false
+        overlayView.addSubview(dialogView)
+        dialogView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(overlayView)
+
+        NSLayoutConstraint.activate([
+            overlayView.topAnchor.constraint(equalTo: view.topAnchor),
+            overlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            overlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            overlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            dialogView.centerXAnchor.constraint(equalTo: overlayView.centerXAnchor),
+            dialogView.centerYAnchor.constraint(equalTo: overlayView.centerYAnchor),
+            dialogView.leadingAnchor.constraint(
+                greaterThanOrEqualTo: overlayView.leadingAnchor, constant: 20),
+            dialogView.trailingAnchor.constraint(
+                lessThanOrEqualTo: overlayView.trailingAnchor, constant: -20),
+        ])
     }
 }


### PR DESCRIPTION
# Overview
This PR introduces the ability to customize force update dialogs across both UIKit and SwiftUI implementations. The changes provide a flexible and consistent API for developers to create and display custom update dialogs while maintaining the existing default alert behavior.

## Key Changes
Simplified Custom Dialog API: Removed closure parameter complexity, enabling direct usage of Hawk.openAppStore()
Enhanced Type Consistency: Unified API design across SwiftUI and UIKit frameworks
Comprehensive Documentation: Added detailed documentation comments and usage examples
Improved Developer Experience: More intuitive API that reduces learning curve

## Features
Custom Dialog Support: Create your own custom update dialogs instead of using the default alert
Direct App Store Integration: Call Hawk.openAppStore() directly from custom dialogs
Flexible Implementation: Support for both default alerts and custom dialogs
Cross-Framework Consistency: Same API pattern for SwiftUI and UIKit
Backward Compatibility: Existing default alert functionality remains unchanged