### PR TITLE
Fix public extension accessibility and custom dialog visibility

### DIFF
--- a/Sources/Hawk/Public Extensions/SwiftUI+CustomDialogModifier.swift
+++ b/Sources/Hawk/Public Extensions/SwiftUI+CustomDialogModifier.swift
@@ -50,7 +50,7 @@ private struct CustomDialogModifier: ViewModifier {
     }
 }
 
-extension View {
+public extension View {
     /**
      * Checks if the app needs to be force-updated and displays a custom dialog when an update is required.
      * This method allows you to create your own custom update dialog instead of using the default alert.
@@ -76,7 +76,7 @@ extension View {
      * }
      * ```
      */
-    public func showForceUpdateDialogIfNeeded<Content: View>(
+    func showForceUpdateDialogIfNeeded<Content: View>(
         level: UpdateLevel = .minor,
         @ViewBuilder content: () -> Content
     ) -> some View {

--- a/Sources/Hawk/Public Extensions/SwiftUI+CustomDialogModifier.swift
+++ b/Sources/Hawk/Public Extensions/SwiftUI+CustomDialogModifier.swift
@@ -34,19 +34,18 @@ private struct CustomDialogModifier: ViewModifier {
      * - Returns: A modified view that performs the force update check with custom dialog.
      */
     func body(content: Content) -> some View {
-        ZStack {
-            if showUpdateAlert {
-                customDialog
-            }
-
-            content
-                .task {
-                    let needUpdate = await Hawk.checkIsNeedForceUpdate(level: updateLevel)
-                    if needUpdate {
-                        showUpdateAlert = true
-                    }
+        content
+            .task {
+                let needUpdate = await Hawk.checkIsNeedForceUpdate(level: updateLevel)
+                if needUpdate {
+                    showUpdateAlert = true
                 }
-        }
+            }
+            .overlay {
+                if showUpdateAlert {
+                    customDialog
+                }
+            }
     }
 }
 
@@ -84,6 +83,7 @@ public extension View {
             CustomDialogModifier(
                 updateLevel: level,
                 customDialog: AnyView(content())
-            ))
+            )
+        )
     }
 }

--- a/Sources/Hawk/Public Extensions/ViewController+showForceUpdateDialogIfNeeded.swift
+++ b/Sources/Hawk/Public Extensions/ViewController+showForceUpdateDialogIfNeeded.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-extension UIViewController {
+public extension UIViewController {
 
     /**
      * Checks for a forced update at the specified level (major, minor, patch).
@@ -8,7 +8,7 @@ extension UIViewController {
      *
      * - Parameter level: The update level threshold (default = .minor).
      */
-    public func showForceUpdateDialogIfNeeded(level: UpdateLevel = .minor) {
+    func showForceUpdateDialogIfNeeded(level: UpdateLevel = .minor) {
         // Run an asynchronous task on the main actor so alert presentation
         // happens on the main thread.
         Task { @MainActor in
@@ -44,7 +44,7 @@ extension UIViewController {
      * }
      * ```
      */
-    public func showForceUpdateDialogIfNeeded(
+    func showForceUpdateDialogIfNeeded(
         level: UpdateLevel = .minor,
         customDialog: @escaping () -> UIView
     ) {


### PR DESCRIPTION
## Summary
Fixes critical issues for SPM distribution:
- Public extension methods not accessible from external modules
- Custom dialogs not displaying in SwiftUI

## Changes
1. Moved `public` modifier to extension declarations (SPM compatibility)
2. Changed dialog rendering from ZStack to overlay (proper layering)